### PR TITLE
Delayed async handling of conflict fetching

### DIFF
--- a/src/delayer.ts
+++ b/src/delayer.ts
@@ -1,0 +1,76 @@
+'use strict';
+
+export interface ITask<T> {
+	(): T;
+}
+
+export class Delayer<T> {
+
+	public defaultDelay: number;
+	private timeout: any; // Timer
+	private completionPromise: Promise<T>;
+	private onSuccess: (value?: T | Thenable<T>) => void;
+	private task: ITask<T>;
+
+	constructor(defaultDelay: number) {
+		this.defaultDelay = defaultDelay;
+		this.timeout = null;
+		this.completionPromise = null;
+		this.onSuccess = null;
+		this.task = null;
+	}
+
+	public trigger(task: ITask<T>, delay: number = this.defaultDelay): Promise<T> {
+		this.task = task;
+		if (delay >= 0) {
+			this.cancelTimeout();
+		}
+
+		if (!this.completionPromise) {
+			this.completionPromise = new Promise<T>((resolve) => {
+				this.onSuccess = resolve;
+			}).then(() => {
+				this.completionPromise = null;
+				this.onSuccess = null;
+				var result = this.task();
+				this.task = null;
+				return result;
+			});
+		}
+
+		if (delay >= 0 || this.timeout === null) {
+			this.timeout = setTimeout(() => {
+				this.timeout = null;
+				this.onSuccess(null);
+			}, delay >= 0 ? delay : this.defaultDelay);
+		}
+
+		return this.completionPromise;
+	}
+
+	public forceDelivery(): Promise<T> {
+		if (!this.completionPromise) {
+			return null;
+		}
+		this.cancelTimeout();
+		let result = this.completionPromise;
+		this.onSuccess(null);
+		return result;
+	}
+
+	public isTriggered(): boolean {
+		return this.timeout !== null;
+	}
+
+	public cancel(): void {
+		this.cancelTimeout();
+		this.completionPromise = null;
+	}
+
+	private cancelTimeout(): void {
+		if (this.timeout !== null) {
+			clearTimeout(this.timeout);
+			this.timeout = null;
+		}
+	}
+}

--- a/src/services/codelensProvider.ts
+++ b/src/services/codelensProvider.ts
@@ -22,9 +22,9 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
         }
     }
 
-    provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
+    async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
 
-        let conflicts = this.tracker.getConflicts(document);
+        let conflicts = await this.tracker.getConflicts(document);
 
         if (!conflicts || conflicts.length === 0) {
             return null;

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -17,10 +17,11 @@ export interface IDocumentMergeConflict {
     theirs: IMergeRegion;
     splitter: vscode.Range;
 
-    commitEdit(type: CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit);
+    commitEdit(type: CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit);
+    applyEdit(type: CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit);
 }
 
 export interface IDocumentMergeConflictTracker {
-    getConflicts(document: vscode.TextDocument): IDocumentMergeConflict[];
+    getConflicts(document: vscode.TextDocument): PromiseLike<IDocumentMergeConflict[]>;
     forget(document : vscode.TextDocument);
 }

--- a/src/services/mergeConflictParser.ts
+++ b/src/services/mergeConflictParser.ts
@@ -27,7 +27,17 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
 
     }
 
-    public commitEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit) {
+    public commitEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Thenable<boolean> {
+
+        if (edit) {
+            this.applyEdit(type, editor, edit);
+            return Promise.resolve(true);
+        };
+
+        return editor.edit((edit) => this.applyEdit(type, editor, edit));
+    }
+
+    public applyEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit) : void {
         if (type === interfaces.CommitType.Ours) {
             edit.replace(this.range, editor.document.getText(this.ours.content));
         }

--- a/src/services/mergeDecorator.ts
+++ b/src/services/mergeDecorator.ts
@@ -98,10 +98,10 @@ export default class MergeDectorator implements vscode.Disposable {
         }
     }
 
-    private applyDecorations(editor: vscode.TextEditor) {
+    private async applyDecorations(editor: vscode.TextEditor) {
         if (!editor) { return; }
 
-        let conflicts = this.tracker.getConflicts(editor.document);
+        let conflicts = await this.tracker.getConflicts(editor.document);
 
         if (conflicts.length === 0) {
             // TODO: Remove decorations


### PR DESCRIPTION
 - With a text editor command, the supplied edit is invalid in not called in a syncronous manner. Additional changes have been made
 - Added delayer.ts from vscode extension samples to debounce processing