### PR TITLE
Fix codelensProvider import to use correct casing

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import DocumentTracker from './documentTracker';
-import CodeLensProvider from './codeLensProvider';
+import CodeLensProvider from './codelensProvider';
 import CommandHandler from './commandHandler';
 import Decorator from './mergeDecorator';
 


### PR DESCRIPTION
Fix for crash-on startup for linux (or any other case sensitive file system). See #6 