### PR TITLE
Add "Accept both" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Avaliable on the [Visual Studio Extension Marketplace](https://marketplace.visua
 ## Features
 
  - Indivual conflicts are highlighted in each file
- - CodeLens actions to either accept "current" or "incoming" change
+ - Command palette commands for resolving and navigating between merge conflicts (see below)
+ - CodeLens actions to either accept "current", "incoming" or "both" changes
  - Navigation shortcuts between conflicts
 
 ### Commands
@@ -18,6 +19,7 @@ All commands use a double key chord combination by default. First press `Alt+M` 
 
  - `Accept current` - `Alt+M, 1` - Accept current (local) change in the current conflict
  - `Accept incoming` - `Alt+M, 2` - Accept incoming change in the current conflict
+ - `Accept both` - `Alt+M, 3` - Accept the union of both the current and incoming change for the current conflict
  - `Accept selection` - `Alt+M, Enter` - Accept the change the editor cursor is currenty within
  - `Next conflict` - `Alm+M, Down Arrow` - Navigate to the next conflict in the current file
  - `Previous conflict` - `Alm+M, Down Arrow` - Navigate to the previous conflict in the current file
@@ -33,6 +35,7 @@ The following commands are exposed if you wish to customize key bindings (*Prefe
 ```
 better-merge.accept.current
 better-merge.accept.incoming
+better-merge.accept.both
 better-merge.accept.selection
 better-merge.next
 better-merge.previous

--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
             },
             {
                 "category": "Better Merge",
+                "title": "Accept both",
+                "command": "better-merge.accept.both"
+            },
+            {
+                "category": "Better Merge",
                 "title": "Next conflict",
                 "command": "better-merge.next"
             },
@@ -111,6 +116,11 @@
                 "command": "better-merge.accept.incoming",
                 "when": "editorTextFocus",
                 "key": "alt+m 2"
+            },
+            {
+                "command": "better-merge.accept.both",
+                "when": "editorTextFocus",
+                "key": "alt+m 3"
             }
         ]
     },

--- a/src/services/codelensProvider.ts
+++ b/src/services/codelensProvider.ts
@@ -55,8 +55,17 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
                 arguments: ['known-conflict', conflict]
             };
 
-            items.push(new vscode.CodeLens(conflict.range, acceptCurrentCommand));
-            items.push(new vscode.CodeLens(conflict.range, acceptIncomingCommand));
+            let acceptBothCommand: vscode.Command = {
+                command: 'better-merge.accept.both',
+                title: `Accept both changes`,
+                arguments: ['known-conflict', conflict]
+            };
+
+            items.push(
+                new vscode.CodeLens(conflict.range, acceptCurrentCommand),
+                new vscode.CodeLens(conflict.range, acceptIncomingCommand),
+                new vscode.CodeLens(conflict.range, acceptBothCommand)
+            );
         });
 
         return items;

--- a/src/services/commandHandler.ts
+++ b/src/services/commandHandler.ts
@@ -30,6 +30,7 @@ export default class CommandHandler implements vscode.Disposable {
             vscode.commands.registerTextEditorCommand('better-merge.accept.current', this.acceptCurrent, this),
             vscode.commands.registerTextEditorCommand('better-merge.accept.incoming', this.acceptIncoming, this),
             vscode.commands.registerTextEditorCommand('better-merge.accept.selection', this.acceptSelection, this),
+            vscode.commands.registerTextEditorCommand('better-merge.accept.both', this.acceptBoth, this),
             vscode.commands.registerTextEditorCommand('better-merge.accept.all-current', this.acceptAllCurrent, this),
             vscode.commands.registerTextEditorCommand('better-merge.accept.all-incoming', this.acceptAllIncoming, this),
             vscode.commands.registerTextEditorCommand('better-merge.next', this.navigateNext, this),
@@ -43,6 +44,10 @@ export default class CommandHandler implements vscode.Disposable {
 
     acceptIncoming(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args): Promise<void> {
         return this.accept(interfaces.CommitType.Incoming, editor, ...args);
+    }
+
+    acceptBoth(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args): Promise<void> {
+        return this.accept(interfaces.CommitType.Both, editor, ...args);
     }
 
     acceptAllCurrent(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args): Promise<void> {
@@ -119,7 +124,7 @@ export default class CommandHandler implements vscode.Disposable {
 
         let conflict: interfaces.IDocumentMergeConflict = null;
 
-        // If launched with known context, take the conflict from that
+    // If launched with known context, take the conflict from that
         if (args[0] === 'known-conflict') {
             conflict = args[1];
         }

--- a/src/services/documentMergeConflict.ts
+++ b/src/services/documentMergeConflict.ts
@@ -1,0 +1,85 @@
+import * as interfaces from './interfaces';
+import * as vscode from 'vscode';
+
+export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict {
+
+    public range: vscode.Range;
+    public current: interfaces.IMergeRegion;
+    public incoming: interfaces.IMergeRegion;
+    public splitter: vscode.Range;
+
+    constructor(document: vscode.TextDocument, match: RegExpExecArray, offsets?: number[]) {
+        this.range = new vscode.Range(document.positionAt(match.index), document.positionAt(match.index + match[0].length));
+
+        this.current = {
+            name: match[2],
+            header: this.getMatchPositions(document, match, 1, offsets),
+            content: this.getMatchPositions(document, match, 3, offsets),
+        };
+
+        this.splitter = this.getMatchPositions(document, match, 5, offsets);
+
+        this.incoming = {
+            name: match[9],
+            header: this.getMatchPositions(document, match, 8, offsets),
+            content: this.getMatchPositions(document, match, 6, offsets),
+        };
+
+    }
+
+    public commitEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Thenable<boolean> {
+
+        if (edit) {
+
+            this.applyEdit(type, editor, edit);
+            return Promise.resolve(true);
+        };
+
+        return editor.edit((edit) => this.applyEdit(type, editor, edit));
+    }
+
+    public applyEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit) : void {
+        if (type === interfaces.CommitType.Current) {
+            edit.replace(this.range, editor.document.getText(this.current.content));
+        }
+        else if (type === interfaces.CommitType.Incoming) {
+            edit.replace(this.range, editor.document.getText(this.incoming.content));
+        }
+    }
+
+    private getMatchPositions(document: vscode.TextDocument, match: RegExpExecArray, groupIndex: number, offsetGroups?: number[]): vscode.Range {
+        // Javascript doesnt give of offsets within the match, we need to calculate these
+        // based of the prior groups, skipping nested matches (yuck).
+        if (!offsetGroups) {
+            offsetGroups = match.map((i, idx) => idx);
+        }
+
+        let start = match.index;
+
+        for (var i = 0; i < offsetGroups.length; i++) {
+            let value = offsetGroups[i];
+
+            if (value >= groupIndex) {
+                break;
+            }
+
+            start += match[value].length;
+        }
+
+        let targetMatchLength = match[groupIndex].length;
+        let end = (start + targetMatchLength);
+
+        // Move the end up if it's capped by a trailing \r\n, this is so regions don't expand into
+        // the line below, and can be "pulled down" by editing the line below
+        if (match[groupIndex].lastIndexOf('\n') === targetMatchLength - 1) {
+            end--;
+
+            // .. for windows encodings of new lines
+            if (match[groupIndex].lastIndexOf('\r') === targetMatchLength - 2) {
+                end--;
+            }
+        }
+
+        return new vscode.Range(document.positionAt(start), document.positionAt(end));
+    }
+}

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -8,7 +8,8 @@ export interface IMergeRegion {
 
 export enum CommitType {
     Current,
-    Incoming
+    Incoming,
+    Both
 }
 
 export interface IExtensionConfiguration {

--- a/src/services/mergeConflictParser.ts
+++ b/src/services/mergeConflictParser.ts
@@ -1,91 +1,10 @@
 import * as vscode from 'vscode';
 import * as interfaces from './interfaces';
-
-export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict {
-
-    public range: vscode.Range;
-    public current: interfaces.IMergeRegion;
-    public incoming: interfaces.IMergeRegion;
-    public splitter: vscode.Range;
-
-    constructor(document: vscode.TextDocument, match: RegExpExecArray, offsets?: number[]) {
-        this.range = new vscode.Range(document.positionAt(match.index), document.positionAt(match.index + match[0].length));
-
-        this.current = {
-            name: match[2],
-            header: this.getMatchPositions(document, match, 1, offsets),
-            content: this.getMatchPositions(document, match, 3, offsets),
-        };
-
-        this.splitter = this.getMatchPositions(document, match, 5, offsets);
-
-        this.incoming = {
-            name: match[9],
-            header: this.getMatchPositions(document, match, 8, offsets),
-            content: this.getMatchPositions(document, match, 6, offsets),
-        };
-
-    }
-
-    public commitEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Thenable<boolean> {
-
-        if (edit) {
-            this.applyEdit(type, editor, edit);
-            return Promise.resolve(true);
-        };
-
-        return editor.edit((edit) => this.applyEdit(type, editor, edit));
-    }
-
-    public applyEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit) : void {
-        if (type === interfaces.CommitType.Current) {
-            edit.replace(this.range, editor.document.getText(this.current.content));
-        }
-        else if (type === interfaces.CommitType.Incoming) {
-            edit.replace(this.range, editor.document.getText(this.incoming.content));
-        }
-    }
-
-    private getMatchPositions(document: vscode.TextDocument, match: RegExpExecArray, groupIndex: number, offsetGroups?: number[]): vscode.Range {
-        // Javascript doesnt give of offsets within the match, we need to calculate these
-        // based of the prior groups, skipping nested matches (yuck).
-        if (!offsetGroups) {
-            offsetGroups = match.map((i, idx) => idx);
-        }
-
-        let start = match.index;
-
-        for (var i = 0; i < offsetGroups.length; i++) {
-            let value = offsetGroups[i];
-
-            if (value >= groupIndex) {
-                break;
-            }
-
-            start += match[value].length;
-        }
-
-        let targetMatchLength = match[groupIndex].length;
-        let end = (start + targetMatchLength);
-
-        // Move the end up if it's capped by a trailing \r\n, this is so regions don't expand into
-        // the line below, and can be "pulled down" by editing the line below
-        if (match[groupIndex].lastIndexOf('\n') === targetMatchLength - 1) {
-            end--;
-
-            // .. for windows encodings of new lines
-            if (match[groupIndex].lastIndexOf('\r') === targetMatchLength - 2) {
-                end--;
-            }
-        }
-
-        return new vscode.Range(document.positionAt(start), document.positionAt(end));
-    }
-}
+import { DocumentMergeConflict } from './documentMergeConflict';
 
 export class MergeConflictParser {
 
-    static scanDocument(document: vscode.TextDocument): DocumentMergeConflict[] {
+    static scanDocument(document: vscode.TextDocument): interfaces.IDocumentMergeConflict[] {
 
         // Match groups
         // 1: "current" header
@@ -101,7 +20,6 @@ export class MergeConflictParser {
         const offsetGroups = [1, 3, 5, 6, 8]; // Skip inner matches when calculating length
 
         let result: DocumentMergeConflict[] = [];
-
         let text = document.getText();
         let match: RegExpExecArray;
         while (match = conflictMatcher.exec(text)) {


### PR DESCRIPTION
Provides "accept both" functionality for the union of the "current" and "incoming" changes for an individual conflict. 

See #10