### PR TITLE
Fixes #13 & #14 - Endless loop & no incoming changes

### DIFF
--- a/src/services/documentMergeConflict.ts
+++ b/src/services/documentMergeConflict.ts
@@ -91,20 +91,23 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
                 break;
             }
 
-            start += match[value].length;
+            start += match[value] !== undefined ? match[value].length : 0;
         }
 
-        let targetMatchLength = match[groupIndex].length;
+        const groupMatch = match[groupIndex];
+        let targetMatchLength = groupMatch !== undefined ? groupMatch.length : -1;
         let end = (start + targetMatchLength);
 
-        // Move the end up if it's capped by a trailing \r\n, this is so regions don't expand into
-        // the line below, and can be "pulled down" by editing the line below
-        if (match[groupIndex].lastIndexOf('\n') === targetMatchLength - 1) {
-            end--;
-
-            // .. for windows encodings of new lines
-            if (match[groupIndex].lastIndexOf('\r') === targetMatchLength - 2) {
+        if (groupMatch !== undefined) {
+            // Move the end up if it's capped by a trailing \r\n, this is so regions don't expand into
+            // the line below, and can be "pulled down" by editing the line below
+            if (match[groupIndex].lastIndexOf('\n') === targetMatchLength - 1) {
                 end--;
+
+                // .. for windows encodings of new lines
+                if (match[groupIndex].lastIndexOf('\r') === targetMatchLength - 2) {
+                    end--;
+                }
             }
         }
 

--- a/src/services/mergeConflictParser.ts
+++ b/src/services/mergeConflictParser.ts
@@ -16,7 +16,7 @@ export class MergeConflictParser {
         // 7: Garbage  (rouge \n)
         // 8: "incoming" header
         // 9: "incoming" name
-        const conflictMatcher = /(<<<<<<< (.+)\r?\n)^((.*\s)+?)(^=======\r?\n)^((.*\s)+?)(^>>>>>>> (.+)$)/mg;
+        const conflictMatcher = /(<<<<<<< (.+)\r?\n)^((.*\s)+?)(^=======\r?\n)(?:^((.*\s)+?))*?(^>>>>>>> (.+)$)/mg;
         const offsetGroups = [1, 3, 5, 6, 8]; // Skip inner matches when calculating length
 
         let result: DocumentMergeConflict[] = [];


### PR DESCRIPTION
Fixes #13 & #14 

I've fixed the regex to handle the case where there were no incoming changes as well as added that support to the decorations.

I've also added a commit to sandbox the regex with a timeout, so that this can't happen again -- not sure if it is really required or not, but I figured it might be worth it.