### PR TITLE
Fix Empty merge regions for both current and incoming. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ better-merge.accept.all-both
 ## Release Notes
 
 ### 0.6.1
- - Fixed handling of empty incoming merges 
+ - Fixed handling of empty incoming or current merge bodies
  - Fixed potential endless loop when parsing merge conflicts in open files
 
 ### 0.6.0

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ better-merge.accept.all-both
 
 ## Release Notes
 
+### 0.6.1
+ - Fixed handling of empty incoming merges 
+ - Fixed potential endless loop when parsing merge conflicts in open files
+
 ### 0.6.0
  - Update vscode engine version for 1.11.0 compatibility
 
@@ -82,10 +86,3 @@ better-merge.accept.all-both
  - Add user configuration
  - Small UI Tweaks (naming consistency)
 
-### 0.2.x
- - Renamed commands
- - Conflict parsing is now async
- - Expose commands for code lens actions
- - Add "accept all" commands
- - Add "accept current" for focused conflict
- - Add "Next / Previous conflict" navigation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "better-merge",
     "displayName": "Better Merge",
     "description": "Improved git merge conflict support",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "publisher": "pprice",
     "author": {
         "name": "Phil Price",

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -18,14 +18,16 @@ export interface IExtensionConfiguration {
     enableEditorOverview: boolean;
 }
 
-export interface IDocumentMergeConflict {
+export interface IDocumentMergeConflict extends IDocumentMergeConflictDescriptor {
+    commitEdit(type: CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit);
+    applyEdit(type: CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit);
+}
+
+export interface IDocumentMergeConflictDescriptor { 
     range: vscode.Range;
     current: IMergeRegion;
     incoming: IMergeRegion;
     splitter: vscode.Range;
-
-    commitEdit(type: CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit);
-    applyEdit(type: CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit);
 }
 
 export interface IDocumentMergeConflictTracker {

--- a/src/services/mergeConflictParser.ts
+++ b/src/services/mergeConflictParser.ts
@@ -29,15 +29,15 @@ export class MergeConflictParser {
         };
         const context = vm.createContext(sandboxScope);
         const script = new vm.Script(`
-    let match;
-    while (match = conflictMatcher.exec(text)) {
-        // Ensure we don't get stuck in an infinite loop
-        if (match.index === conflictMatcher.lastIndex) {
-            conflictMatcher.lastIndex++;
-        }
+            let match;
+            while (match = conflictMatcher.exec(text)) {
+                // Ensure we don't get stuck in an infinite loop
+                if (match.index === conflictMatcher.lastIndex) {
+                    conflictMatcher.lastIndex++;
+                }
 
-        result.push(match);
-    }`);
+                result.push(match);
+            }`);
 
         try {
             // If the regex takes longer than 1s consider it dead

--- a/src/services/mergeConflictParser.ts
+++ b/src/services/mergeConflictParser.ts
@@ -7,17 +7,23 @@ import * as util from 'util';
 export class MergeConflictParser {
 
     static scanDocument(document: vscode.TextDocument): interfaces.IDocumentMergeConflict[] {
+
         // Conflict matching regex, comments are in the format of "description - [group index] group name"
+        // Premise is: Match the current change (<<<<<<), match anything up to the splitter (======) then 
+        // match anything up to the incoming change (>>>>>>), this leaves some oddities with newlines not being
+        // pulled into the "body" of each change, DocumentMergeConflict.applyEdit will deal with these cases 
+        // and append newlines when needed 
+
         const conflictMatcher = new RegExp([
-                /(<<<<<<< (.+)\r?\n)/,          // "Current" conflict header - [1] entire line, [2] name
-                /^((.*\s)+?)/,                  // "Current" conflict body - [3] body text, [4] garbage
-                /(^=======\r?\n)/,              // Splitter - [5] entire line
-                /(?:^((.*\s)+?))*?/,            // Incoming conflict body - [6] content, [7] garbage
-                /(^>>>>>>> (.+)$)/              // Incoming conflict header - [8] entire line, [2] name
+                /(^<<<<<<<\s(.+)\r?\n)/,             // "Current" conflict header - [1] entire line, [2] name
+                /([\s\S]*?)/,                        // "Current" conflict body - [3] body text
+                /(^=======\r?\n)/,                   // Splitter - [4] entire line
+                /([\s\S]*?)/,                        // Incoming conflict body - [5]
+                /(^>>>>>>>\s(.+)\r?\n)/              // Incoming conflict header - [6] entire line, [7] name
             ].map(r => r.source).join(''), 
             'mg');
         
-        const offsetGroups = [1, 3, 5, 6, 8]; // Skip inner matches when calculating length
+        const offsetGroups = [1, 3, 4, 5, 6]; // Skip inner matches when calculating length
 
         let text = document.getText();
         let sandboxScope = {
@@ -45,7 +51,7 @@ export class MergeConflictParser {
             return [];
         }
 
-        return sandboxScope.result.map(match => new DocumentMergeConflict(document, match, offsetGroups));
+        return sandboxScope.result.map(match => new DocumentMergeConflict(document, MergeConflictParser.matchesToDescriptor(document, match, offsetGroups)));
     }
 
     static containsConflict(document: vscode.TextDocument): boolean {
@@ -56,6 +62,66 @@ export class MergeConflictParser {
         // TODO: Ask source control if the file contains a conflict
         let text = document.getText();
         return text.includes('<<<<<<<') && text.includes('>>>>>>>');
+    }
+
+    static matchesToDescriptor(document: vscode.TextDocument, match: RegExpExecArray, offsets?: number[]) : interfaces.IDocumentMergeConflictDescriptor {
+        
+        var item : interfaces.IDocumentMergeConflictDescriptor = { 
+            range: new vscode.Range(document.positionAt(match.index), document.positionAt(match.index + match[0].length)),
+            current: {
+                name: match[2],
+                header: this.getMatchPositions(document, match, 1, offsets),
+                content: this.getMatchPositions(document, match, 3, offsets),
+            },
+            splitter: this.getMatchPositions(document, match, 4, offsets),
+            incoming: {
+                name: match[9],
+                header: this.getMatchPositions(document, match, 6, offsets),
+                content: this.getMatchPositions(document, match, 5, offsets),
+            }
+        }
+
+        return item; 
+    }
+
+     
+    static getMatchPositions(document: vscode.TextDocument, match: RegExpExecArray, groupIndex: number, offsetGroups?: number[]): vscode.Range {
+        // Javascript doesnt give of offsets within the match, we need to calculate these
+        // based of the prior groups, skipping nested matches (yuck).
+        if (!offsetGroups) {
+            offsetGroups = match.map((i, idx) => idx);
+        }
+
+        let start = match.index;
+
+        for (var i = 0; i < offsetGroups.length; i++) {
+            let value = offsetGroups[i];
+
+            if (value >= groupIndex) {
+                break;
+            }
+
+            start += match[value] !== undefined ? match[value].length : 0;
+        }
+
+        const groupMatch = match[groupIndex];
+        let targetMatchLength = groupMatch !== undefined ? groupMatch.length : -1;
+        let end = (start + targetMatchLength);
+
+        if (groupMatch !== undefined) {
+            // Move the end up if it's capped by a trailing \r\n, this is so regions don't expand into
+            // the line below, and can be "pulled down" by editing the line below
+            if (match[groupIndex].lastIndexOf('\n') === targetMatchLength - 1) {
+                end--;
+
+                // .. for windows encodings of new lines
+                if (match[groupIndex].lastIndexOf('\r') === targetMatchLength - 2) {
+                    end--;
+                }
+            }
+        }
+
+        return new vscode.Range(document.positionAt(start), document.positionAt(end));
     }
 
 }

--- a/src/services/mergeConflictParser.ts
+++ b/src/services/mergeConflictParser.ts
@@ -7,18 +7,16 @@ import * as util from 'util';
 export class MergeConflictParser {
 
     static scanDocument(document: vscode.TextDocument): interfaces.IDocumentMergeConflict[] {
-
-        // Match groups
-        // 1: "current" header
-        // 2: "current" name
-        // 3: "current" content
-        // 4: Garbage (rouge \n)
-        // 5: Splitter
-        // 6: "incoming" content
-        // 7: Garbage  (rouge \n)
-        // 8: "incoming" header
-        // 9: "incoming" name
-        const conflictMatcher = /(<<<<<<< (.+)\r?\n)^((.*\s)+?)(^=======\r?\n)(?:^((.*\s)+?))*?(^>>>>>>> (.+)$)/mg;
+        // Conflict matching regex, comments are in the format of "description - [group index] group name"
+        const conflictMatcher = new RegExp([
+                /(<<<<<<< (.+)\r?\n)/,          // "Current" conflict header - [1] entire line, [2] name
+                /^((.*\s)+?)/,                  // "Current" conflict body - [3] body text, [4] garbage
+                /(^=======\r?\n)/,              // Splitter - [5] entire line
+                /(?:^((.*\s)+?))*?/,            // Incoming conflict body - [6] content, [7] garbage
+                /(^>>>>>>> (.+)$)/              // Incoming conflict header - [8] entire line, [2] name
+            ].map(r => r.source).join(''), 
+            'mg');
+        
         const offsetGroups = [1, 3, 5, 6, 8]; // Skip inner matches when calculating length
 
         let text = document.getText();


### PR DESCRIPTION
 - [Refactor] Pull range generation implementation into MergeConflictParser
 - [Refactor] Change construction of DocumentMergeConflict to take IDocumentMergeConflictDescriptor
 - Simplify regex used for matching to allow empty content areas
 - Update IDocumentMergeConflictDescriptor.applyEdit to cope with empty regions, and append newlines where needed.