### PR TITLE
Adds ability to compare the current and incoming changes

### DIFF
--- a/src/services/codelensProvider.ts
+++ b/src/services/codelensProvider.ts
@@ -63,8 +63,8 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 
             items.push(
                 new vscode.CodeLens(conflict.range, acceptCurrentCommand),
-                new vscode.CodeLens(conflict.range, acceptIncomingCommand),
-                new vscode.CodeLens(conflict.range, acceptBothCommand)
+                new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 1 })), acceptIncomingCommand),
+                new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 2 })), acceptBothCommand)
             );
         });
 

--- a/src/services/codelensProvider.ts
+++ b/src/services/codelensProvider.ts
@@ -61,10 +61,17 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
                 arguments: ['known-conflict', conflict]
             };
 
+            let diffCommand: vscode.Command = {
+                command: 'better-merge.diff',
+                title: `Compare changes`,
+                arguments: [conflict]
+            };
+
             items.push(
                 new vscode.CodeLens(conflict.range, acceptCurrentCommand),
                 new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 1 })), acceptIncomingCommand),
-                new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 2 })), acceptBothCommand)
+                new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 2 })), acceptBothCommand),
+                new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 3 })), diffCommand)
             );
         });
 

--- a/src/services/contentProvider.ts
+++ b/src/services/contentProvider.ts
@@ -1,0 +1,34 @@
+'use strict';
+import * as vscode from 'vscode';
+import * as interfaces from './interfaces';
+
+export default class MergeConflictContentProvider implements vscode.TextDocumentContentProvider, vscode.Disposable {
+
+    static scheme = 'better-merge.conflict-diff';
+
+    constructor(private context: vscode.ExtensionContext) {
+    }
+
+    begin(config : interfaces.IExtensionConfiguration) {
+        this.context.subscriptions.push(
+            vscode.workspace.registerTextDocumentContentProvider(MergeConflictContentProvider.scheme, this)
+        );
+    }
+
+    dispose() {
+    }
+
+    async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+        try {
+            const [start, end] = JSON.parse(uri.query) as { line: number, character: number }[];
+
+            const document = await vscode.workspace.openTextDocument(uri.with({ scheme: 'file', query: undefined }));
+            const text = document.getText(new vscode.Range(start.line, start.character, end.line, end.character));
+            return text;
+        }
+        catch (ex) {
+            await vscode.window.showErrorMessage('Unable to show comparison');
+            return undefined;
+        }
+    }
+}

--- a/src/services/documentMergeConflict.ts
+++ b/src/services/documentMergeConflict.ts
@@ -39,11 +39,11 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
         // ]
         if (type === interfaces.CommitType.Current) {
             // Replace [ Conflict Range ] with [ Current Content ]
-            var content = editor.document.getText(this.current.content);
+            let content = editor.document.getText(this.current.content);
             this.replaceRangeWithContent(content, edit);
         }
         else if (type === interfaces.CommitType.Incoming) {
-            var content = editor.document.getText(this.incoming.content);
+            let content = editor.document.getText(this.incoming.content);
             this.replaceRangeWithContent(content, edit);
         }
         else if (type === interfaces.CommitType.Both) {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import DocumentTracker from './documentTracker';
 import CodeLensProvider from './codelensProvider';
 import CommandHandler from './commandHandler';
+import ContentProvider from './contentProvider';
 import Decorator from './mergeDecorator';
 
 const ConfigurationSectionName = 'better-merge';
@@ -22,6 +23,7 @@ export default class ServiceWrapper implements vscode.Disposable {
             documentTracker,
             new CommandHandler(this.context, documentTracker),
             new CodeLensProvider(this.context, documentTracker),
+            new ContentProvider(this.context),
             new Decorator(this.context, documentTracker),
         );
 


### PR DESCRIPTION
This is something I've been wanting for a while now and I feel like it fits in well with the spirit of better-merge (hopefully you do too!).

This PR fixes #21 and adds a `Compare changes` code lens at the end. Clicking on the code lens, opens a diff of the current vs incoming changes for that conflict.

Let me know what you think.